### PR TITLE
fix: update broken just.systems/man/en/ URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ justx run -g docker:shell my-image
 
 ## Local recipes and modules
 
-If you run `justx` from a directory that contains a `justfile`, its recipes appear automatically in the TUI. **justx** also supports `just`'s native [module system](https://just.systems/man/en/modules1.html) — any modules declared in your justfile are discovered and shown as separate sources.
+If you run `justx` from a directory that contains a `justfile`, its recipes appear automatically in the TUI. **justx** also supports `just`'s native [module system](https://just.systems/man/en/modules.html) — any modules declared in your justfile are discovered and shown as separate sources.
 
 ```just
 # justfile

--- a/docs/configuration/local.md
+++ b/docs/configuration/local.md
@@ -27,7 +27,7 @@ dev:
 
 ## Organising with modules
 
-As your justfile grows, you can split recipes into separate files using `just`'s native [module system](https://just.systems/man/en/modules1190.html). Declare a module in your root justfile with `mod`, and `just` looks for the source file in this order:
+As your justfile grows, you can split recipes into separate files using `just`'s native [module system](https://just.systems/man/en/modules.html). Declare a module in your root justfile with `mod`, and `just` looks for the source file in this order:
 
 - `<name>.just`
 - `<name>/mod.just`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -45,7 +45,7 @@ navigate to the recipe you want to run, and press `Enter`. If the recipe has inp
 
 If you run `justx` from a directory that already contains a `justfile`, it will appear automatically in the Sources pane alongside your global recipes — no extra setup needed.
 
-Any [modules](https://just.systems/man/en/modules1.html) declared in your justfile are also discovered and shown as separate sources in the TUI.
+Any [modules](https://just.systems/man/en/modules.html) declared in your justfile are also discovered and shown as separate sources in the TUI.
 
 ## Verify your setup
 

--- a/kitchen-sink-example.just
+++ b/kitchen-sink-example.just
@@ -197,7 +197,7 @@ justwords:
     > /tmp/justwords
 
 # Subsequent dependencies
-# https://just.systems/man/en/chapter_37.html
+# https://just.systems/man/en/dependencies.html#running-recipes-at-the-end-of-a-recipe
 # To test, run `$ just -f test-suite.just b`
 a:
   echo 'A!'


### PR DESCRIPTION
- modules1.html → modules.html (README.md, docs/getting-started.md)
- modules1190.html → modules.html (docs/configuration/local.md)
- chapter_37.html → dependencies.html#running-recipes-at-the-end-of-a-recipe (kitchen-sink-example.just)

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated
- [ ] We don't currently have unit tests for the TUI yet. If you've made changes;
    - [ ] Verify the TUI works as expected
    - [ ] HJKL-navigation works as expected

**Description of changes**

Fix broken links to just.systems/man/en/ documentation. Four URLs across docs and example files were pointing to 404 pages due to outdated links.
